### PR TITLE
Convert blocks to json in post message

### DIFF
--- a/lib/slack/endpoint/chat.rb
+++ b/lib/slack/endpoint/chat.rb
@@ -49,6 +49,7 @@ module Slack
         throw ArgumentError.new("Required arguments :channel missing") if options[:channel].nil?
         throw ArgumentError.new("Required arguments :text missing") if options[:text].nil?
         options[:attachments] = options[:attachments].to_json if options[:attachments]
+        options[:blocks] = options[:blocks].to_json if options[:blocks]
         post("chat.postMessage", options)
       end
 


### PR DESCRIPTION
I am using blocks in the Slack message to post celebrations in [This PR](https://github.com/pingboard/pingboard/pull/4465). Blocks must be in JSON, so we can convert it here like we do for attachments.